### PR TITLE
Added MANIFEST.in to create an installable source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+include LICENSE
+include AUTHORS.rst
+


### PR DESCRIPTION
the source distributions registered on PyPI don't contains README.rst, so they are not installable via pip.
