### PR TITLE
adding RFC2047 style encoding support

### DIFF
--- a/test_outbox.py
+++ b/test_outbox.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 import base64
 
@@ -72,12 +72,12 @@ def test_email_errors_bodies():
 
 def test_email():
     e = Email(recipients=['nathan@getoffmalawn.com'], subject='subject',
-            body='body', fields={'Reply-To':'nobody@nowhere.com'})
+              body='body', fields={'Reply-To': 'nobody@nowhere.com'})
 
     assert e.body == 'body'
     assert e.subject == 'subject'
     assert e.recipients == ['nathan@getoffmalawn.com']
-    assert e.fields == {'Reply-To':'nobody@nowhere.com'}
+    assert e.fields == {'Reply-To': 'nobody@nowhere.com'}
 
 
 def test_single_recipient_becomes_list():

--- a/test_outbox.py
+++ b/test_outbox.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import base64
+from email.header import decode_header
 
 try:
     from unittest import mock
@@ -42,6 +43,21 @@ def test_attachment_file():
     assert attachment.name == 'my filename'
     assert attachment.raw == b'foo data'
     assert attachment.read() == b'foo data'
+
+
+def test_rfc2231():
+    filename = u'ファイル名'
+    a = [Attachment(filename, fileobj=StringIO('this is some data'))]
+
+    e = Email(['test@example.com'], 'subject', 'body')
+    assert e.as_mime(a).get_payload()[1].get_filename() == filename
+
+    e = Email(['test@example.com'], 'subject', 'body', rfc2231=True)
+    assert e.as_mime(a).get_payload()[1].get_filename() == filename
+
+    e = Email(['test@example.com'], 'subject', 'body', rfc2231=False)
+    h, enc = decode_header(e.as_mime(a).get_payload()[1].get_filename())[0]
+    assert h.decode(enc) == filename
 
 
 def test_email_errors_recipients():
@@ -160,6 +176,7 @@ if __name__ == '__main__':
     test_encoding()
     test_attachment_raw_data()
     test_attachment_file()
+    test_rfc2231()
     test_email_errors_recipients()
     test_email_errors_bodies()
     test_email()


### PR DESCRIPTION
I wrote a simple send to kindle script using Outbox :)

I noticed the service did not find any attachment with Japanese file name.
after some try&error, I found the service only understand "RFC2047" style file name

Here is the send to kindle script: https://gist.github.com/hideaki-t/c8a922f2a5b1f98a8bc5
